### PR TITLE
fix: enforce task gate and persist post-merge task advancement

### DIFF
--- a/.github/workflows/post-merge-advance.yml
+++ b/.github/workflows/post-merge-advance.yml
@@ -20,3 +20,15 @@ jobs:
 
       - name: Advance task
         run: python3 scripts/controller.py advance
+
+      - name: Commit and push updated task state
+        run: |
+          if git diff --quiet; then
+            echo "No task state changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add orchestration/current-task.json orchestration/tasks.json
+          git commit -m "chore: advance orchestration task state after merge"
+          git push

--- a/.github/workflows/task-gate.yml
+++ b/.github/workflows/task-gate.yml
@@ -21,4 +21,4 @@ jobs:
         run: cat orchestration/current-task.json
 
       - name: Check merge readiness
-        run: python3 scripts/controller.py ready
+        run: bash scripts/check-task-ready.sh


### PR DESCRIPTION
### Motivation
- Ensure the PR Task Gate actually blocks merges when the orchestration state is not ready by running a command that can fail the job.  
- Persist task state changes performed in CI after a successful merge so the repo reflects advanced tasks.

### Description
- Updated `.github/workflows/task-gate.yml` to run `bash scripts/check-task-ready.sh` instead of `python3 scripts/controller.py ready` so the workflow exits non-zero when not ready.  
- Updated `.github/workflows/post-merge-advance.yml` to commit and push `orchestration/current-task.json` and `orchestration/tasks.json` after running `python3 scripts/controller.py advance` so state changes persist in the repo.

### Testing
- Ran syntax checks with `bash -n scripts/start-task.sh`, `bash -n scripts/advance-task.sh`, and `bash -n scripts/check-task-ready.sh`, and they succeeded.  
- Validated Python and JSON with `python3 -m py_compile scripts/controller.py` and `python3 -m json.tool` on `orchestration/*` templates and JSON files, and they succeeded.  
- Executed `bash scripts/check-task-ready.sh` against the current pending state and it printed `NOT_READY` and exited non-zero as expected, confirming the gate is now blocking when readiness criteria are unmet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cce8df6ee88322aff9975c055e8286)