### PR TITLE
feat: add single-trigger Builder→Reviewer→Product chain orchestration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           test -f scripts/advance-task.sh
           test -f scripts/check-task-ready.sh
           test -f scripts/controller.py
+          test -f scripts/run-task-chain.py
 
       - name: Validate JSON files
         run: |
@@ -55,3 +56,4 @@ jobs:
       - name: Check Python syntax
         run: |
           python3 -m py_compile scripts/controller.py
+          python3 -m py_compile scripts/run-task-chain.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # auto-forge
+
+## Autonomous task chain (single trigger)
+
+This repo now supports a **single command trigger** that runs the three-agent sequence in order:
+
+1. Builder
+2. Reviewer
+3. Product reviewer
+
+Use:
+
+```bash
+python3 scripts/run-task-chain.py <task_id> \
+  --builder-cmd '<builder command with {task_id}>' \
+  --reviewer-cmd '<reviewer command with {task_id}>' \
+  --product-cmd '<product command with {task_id}>' \
+  --review-result orchestration/review-result.json \
+  --product-result orchestration/product-result.json
+```
+
+### What this chain updates automatically
+
+- Starts the task state (`scripts/start-task.sh`) unless `--no-start` is used.
+- Marks Builder done when Builder command exits successfully.
+- Reads reviewer decision JSON and sets reviewer status:
+  - `MERGE` => approved
+  - anything else => changes requested (chain stops)
+- Reads product decision JSON and sets product status:
+  - `PROCEED` => approved
+  - anything else => changes requested (chain stops)
+
+### What remains intentionally separate/manual
+
+- **CI status remains separate and honest by design.**
+- The chain does **not** mark CI passed automatically.
+- CI must still update independently using:
+
+```bash
+python3 scripts/controller.py ci-passed
+# or
+python3 scripts/controller.py ci-failed
+```
+
+### Current tooling reality
+
+Full chaining is possible only if your environment can run each agent non-interactively from a command (the `--*-cmd` values).
+
+If your local/CI agent runner cannot be called via command line yet, then invoking the Builder/Reviewer/Product commands is still the missing piece; the chain script is already in place to orchestrate once those commands exist.

--- a/scripts/run-task-chain.py
+++ b/scripts/run-task-chain.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Run Builder -> Reviewer -> Product Reviewer as a single chained trigger.
+
+This script keeps CI separate: it only advances agent-review state in
+orchestration/current-task.json. CI status is still updated independently.
+"""
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+CURRENT = Path("orchestration/current-task.json")
+CONTROLLER = ["python3", "scripts/controller.py"]
+
+
+def run_cmd(cmd: str, stage: str, task_id: int) -> None:
+    rendered = cmd.format(task_id=task_id)
+    print(f"[{stage}] running: {rendered}")
+    result = subprocess.run(rendered, shell=True)
+    if result.returncode != 0:
+        raise SystemExit(f"[{stage}] command failed with exit code {result.returncode}")
+
+
+def controller(command: str) -> None:
+    subprocess.run([*CONTROLLER, command], check=True)
+
+
+def load_json(path: Path) -> dict:
+    if not path.exists():
+        raise SystemExit(f"Missing required result file: {path}")
+    return json.loads(path.read_text())
+
+
+def apply_reviewer_decision(path: Path) -> None:
+    data = load_json(path)
+    decision = data.get("decision", "").strip().upper()
+    if decision == "MERGE":
+        controller("reviewer-approved")
+        return
+    controller("reviewer-rejected")
+    raise SystemExit(f"[reviewer] not approved (decision={decision})")
+
+
+def apply_product_decision(path: Path) -> None:
+    data = load_json(path)
+    decision = data.get("decision", "").strip().upper()
+    if decision == "PROCEED":
+        controller("product-approved")
+        return
+    controller("product-rejected")
+    raise SystemExit(f"[product] not approved (decision={decision})")
+
+
+def start_task(task_id: int) -> None:
+    subprocess.run(["bash", "scripts/start-task.sh", str(task_id)], check=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Single-trigger chain for Builder -> Reviewer -> Product Reviewer"
+    )
+    parser.add_argument("task_id", type=int, help="Task number to execute")
+    parser.add_argument(
+        "--builder-cmd",
+        required=True,
+        help=(
+            "Command used to run the Builder agent. "
+            "Use {task_id} to interpolate task id."
+        ),
+    )
+    parser.add_argument(
+        "--reviewer-cmd",
+        required=True,
+        help=(
+            "Command used to run the Reviewer agent. "
+            "Use {task_id} to interpolate task id."
+        ),
+    )
+    parser.add_argument(
+        "--product-cmd",
+        required=True,
+        help=(
+            "Command used to run the Product reviewer agent. "
+            "Use {task_id} to interpolate task id."
+        ),
+    )
+    parser.add_argument(
+        "--review-result",
+        default="orchestration/review-result.json",
+        help="Path to reviewer JSON result file (contains decision)",
+    )
+    parser.add_argument(
+        "--product-result",
+        default="orchestration/product-result.json",
+        help="Path to product JSON result file (contains decision)",
+    )
+    parser.add_argument(
+        "--no-start",
+        action="store_true",
+        help="Do not call scripts/start-task.sh (use current task state as-is)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.no_start:
+        start_task(args.task_id)
+
+    run_cmd(args.builder_cmd, "builder", args.task_id)
+    controller("builder-done")
+
+    run_cmd(args.reviewer_cmd, "reviewer", args.task_id)
+    apply_reviewer_decision(Path(args.review_result))
+
+    run_cmd(args.product_cmd, "product", args.task_id)
+    apply_product_decision(Path(args.product_result))
+
+    state = json.loads(CURRENT.read_text())
+    print("[chain] completed agent sequence")
+    print(json.dumps(state, indent=2))
+    print("[chain] CI remains separate. Update with scripts/controller.py ci-passed|ci-failed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a single-command runner that triggers the existing Builder, Reviewer, and Product reviewer stages in sequence so a task can be started once and progress through agent stages automatically. 
- Use the existing orchestration primitives (`orchestration/current-task.json`, `scripts/controller.py`, and gate checks) without redesigning the system. 
- Keep CI gating separate and honest so CI status must still be set independently. 

### Description
- Add `scripts/run-task-chain.py`, a minimal orchestrator that optionally calls `scripts/start-task.sh`, runs the Builder, Reviewer, and Product commands in order, and updates state via `python3 scripts/controller.py` (`builder-done`, reviewer/product approve/reject paths). 
- The chain reads reviewer and product JSON result files (defaults `orchestration/review-result.json` and `orchestration/product-result.json`) and applies approvals only for `MERGE` and `PROCEED` respectively, stopping the chain on non-approval. 
- Update `README.md` with usage and explicit boundaries (what the chain automates and what remains manual). 
- Update CI checks in `.github/workflows/ci.yml` to require and syntax-check `scripts/run-task-chain.py` and to `py_compile` the new script. 

### Testing
- Validated bash syntax with `bash -n` for `scripts/start-task.sh`, `scripts/advance-task.sh`, and `scripts/check-task-ready.sh`, and the checks passed. 
- Validated Python syntax with `python3 -m py_compile` for `scripts/controller.py` and `scripts/run-task-chain.py`, and JSON sanity with `python3 -m json.tool` for `orchestration/*` templates, and all checks succeeded. 
- Executed the combined validation command that runs the above checks and it completed successfully (printed `OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cced5de6d883228475e98317bf87c4)