### PR TITLE
Add thin wrapper scripts and README instructions for running agent task chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,23 @@ python3 scripts/controller.py ci-failed
 Full chaining is possible only if your environment can run each agent non-interactively from a command (the `--*-cmd` values).
 
 If your local/CI agent runner cannot be called via command line yet, then invoking the Builder/Reviewer/Product commands is still the missing piece; the chain script is already in place to orchestrate once those commands exist.
+
+## Thin wrapper commands (smallest practical setup)
+
+To avoid hand-crafting long per-role command strings each run, use these wrappers:
+
+- `scripts/run-builder.sh`
+- `scripts/run-reviewer.sh`
+- `scripts/run-product.sh`
+
+Each wrapper currently uses an environment-specific placeholder executable (`forge-agent` by default, or `$FORGE_AGENT_CMD` if set). You must swap this for your real agent runner in your environment.
+
+Run Task 1 with one command:
+
+```bash
+python3 scripts/run-task-chain.py 1 \
+  --builder-cmd 'bash scripts/run-builder.sh {task_id}' \
+  --reviewer-cmd 'bash scripts/run-reviewer.sh {task_id}' \
+  --product-cmd 'bash scripts/run-product.sh {task_id}'
+```
+

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_ID="${1:-}"
+if [[ -z "$TASK_ID" ]]; then
+  echo "Usage: ./scripts/run-builder.sh <task-id>"
+  exit 1
+fi
+
+# TODO: Replace this one line with your real Builder agent runner.
+FORGE_AGENT_CMD="${FORGE_AGENT_CMD:-forge-agent}"
+"$FORGE_AGENT_CMD" run --role builder --task-id "$TASK_ID" --output orchestration/task-result.json

--- a/scripts/run-product.sh
+++ b/scripts/run-product.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_ID="${1:-}"
+if [[ -z "$TASK_ID" ]]; then
+  echo "Usage: ./scripts/run-product.sh <task-id>"
+  exit 1
+fi
+
+# TODO: Replace this one line with your real Product reviewer agent runner.
+FORGE_AGENT_CMD="${FORGE_AGENT_CMD:-forge-agent}"
+"$FORGE_AGENT_CMD" run --role product --task-id "$TASK_ID" --output orchestration/product-result.json

--- a/scripts/run-reviewer.sh
+++ b/scripts/run-reviewer.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_ID="${1:-}"
+if [[ -z "$TASK_ID" ]]; then
+  echo "Usage: ./scripts/run-reviewer.sh <task-id>"
+  exit 1
+fi
+
+# TODO: Replace this one line with your real Reviewer agent runner.
+FORGE_AGENT_CMD="${FORGE_AGENT_CMD:-forge-agent}"
+"$FORGE_AGENT_CMD" run --role reviewer --task-id "$TASK_ID" --output orchestration/review-result.json


### PR DESCRIPTION
### Motivation
- Provide a minimal, repeatable way to invoke Builder/Reviewer/Product agents without hand-crafting long per-role command strings.
- Make it easier to run the existing task chaining orchestration by offering small wrapper scripts and example usage in the `README.md`.

### Description
- Add a new "Thin wrapper commands" section to `README.md` with example invocation for running Task 1 using `python3 scripts/run-task-chain.py` and wrapper scripts.
- Add three executable wrapper scripts: `scripts/run-builder.sh`, `scripts/run-reviewer.sh`, and `scripts/run-product.sh` to standardize per-role command lines.
- Each wrapper accepts a `<task-id>`, validates the argument, uses `FORGE_AGENT_CMD` defaulting to `forge-agent`, and writes role-specific output into `orchestration/*.json`.
- Each script uses `set -euo pipefail` and a simple usage message to fail fast on incorrect invocation.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cceff367c4832280e451cbebfbb760)