### PR TITLE
Pivot orchestration docs to GitHub-first + Codex-cloud-first model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,6 +62,57 @@ bootstrap app
 
 docs site
 
+## Orchestration architecture (Tasks 1–19)
+
+Primary model:
+
+- **GitHub-first control plane**
+- **Codex-cloud-first execution plane**
+
+### Control plane (GitHub)
+
+- Task issues (`Task1`..`Task19`) track lifecycle.
+- Labels and PR comments encode workflow state.
+- PRs are implementation artifacts.
+- GitHub checks are the only CI truth.
+
+### Execution plane (Codex cloud)
+
+- Builder agent implements task changes on a branch and updates PR.
+- Reviewer agent evaluates against `REVIEW_RUBRIC.md`.
+- Product-reviewer agent evaluates against vision/product docs.
+
+### Role/state model
+
+Roles:
+
+- Builder
+- Reviewer
+- Product-reviewer
+
+States:
+
+- ready
+- in-progress
+- review
+- product-review
+- done
+- blocked
+
+### Honest boundary
+
+Automated in first practical version:
+
+- Builder trigger from GitHub event.
+- PR creation/update.
+- Label transitions to review stage.
+
+Still manual initially:
+
+- Reviewer/product-reviewer trigger wiring (until enabled).
+- Merge decision execution.
+- Exception/retry operations.
+
 ## rules
 
 simple

--- a/README.md
+++ b/README.md
@@ -1,69 +1,157 @@
 # auto-forge
 
-## Autonomous task chain (single trigger)
+## Pivot: Codex-cloud-first + GitHub-first orchestration
 
-This repo now supports a **single command trigger** that runs the three-agent sequence in order:
+This repository is now oriented around a **GitHub control plane** and **Codex cloud execution**.
 
-1. Builder
-2. Reviewer
-3. Product reviewer
+### Design goals for Tasks 1–19
 
-Use:
+1. GitHub is the source of truth for task state.
+2. Codex cloud does implementation/review work where available.
+3. PRs, labels, comments, and statuses drive flow.
+4. Roles are explicit: **Builder**, **Reviewer**, **Product-reviewer**.
+5. We clearly separate what is automatable today vs what remains manual.
 
-```bash
-python3 scripts/run-task-chain.py <task_id> \
-  --builder-cmd '<builder command with {task_id}>' \
-  --reviewer-cmd '<reviewer command with {task_id}>' \
-  --product-cmd '<product command with {task_id}>' \
-  --review-result orchestration/review-result.json \
-  --product-result orchestration/product-result.json
-```
+---
 
-### What this chain updates automatically
+## Smallest practical target architecture
 
-- Starts the task state (`scripts/start-task.sh`) unless `--no-start` is used.
-- Marks Builder done when Builder command exits successfully.
-- Reads reviewer decision JSON and sets reviewer status:
-  - `MERGE` => approved
-  - anything else => changes requested (chain stops)
-- Reads product decision JSON and sets product status:
-  - `PROCEED` => approved
-  - anything else => changes requested (chain stops)
+### Control plane (GitHub)
 
-### What remains intentionally separate/manual
+- **Issues** represent Task1..Task19 (one issue per task).
+- **Labels** represent stage/state, e.g.:
+  - `task:<id>`
+  - `role:builder`, `role:reviewer`, `role:product`
+  - `state:ready`, `state:in-progress`, `state:review`, `state:product-review`, `state:done`, `state:blocked`
+- **PR** is the execution artifact for a task.
+- **Comments** are used for handoffs and manual approvals/rejections.
+- **Commit status / checks** represent CI truth; orchestration must not fake them.
 
-- **CI status remains separate and honest by design.**
-- The chain does **not** mark CI passed automatically.
-- CI must still update independently using:
+### Execution plane (Codex cloud)
 
-```bash
-python3 scripts/controller.py ci-passed
-# or
-python3 scripts/controller.py ci-failed
-```
+- Builder role runs in Codex cloud (or closest available hosted runner) to create code changes and open/update PR.
+- Reviewer role runs in Codex cloud to evaluate implementation against `REVIEW_RUBRIC.md` and post decision comment.
+- Product-reviewer role runs in Codex cloud to evaluate product fit against `VISION.md`, `PRODUCT.md`, `QUALITY_BAR.md` and post decision comment.
 
-### Current tooling reality
+### Role contract
 
-Full chaining is possible only if your environment can run each agent non-interactively from a command (the `--*-cmd` values).
+- **Builder output**: branch + PR + summary comment.
+- **Reviewer output**: `MERGE` or `CHANGES_REQUESTED` decision comment.
+- **Product-reviewer output**: `PROCEED` or `CHANGES_REQUESTED` decision comment.
+- **CI output**: pass/fail from GitHub checks only.
 
-If your local/CI agent runner cannot be called via command line yet, then invoking the Builder/Reviewer/Product commands is still the missing piece; the chain script is already in place to orchestrate once those commands exist.
+---
 
-## Thin wrapper commands (smallest practical setup)
+## Honest automation boundary (today)
 
-To avoid hand-crafting long per-role command strings each run, use these wrappers:
+What can be automated today (smallest practical level):
 
-- `scripts/run-builder.sh`
-- `scripts/run-reviewer.sh`
-- `scripts/run-product.sh`
+- Triggering from GitHub labels/comments.
+- Running a single Builder pass in Codex cloud.
+- Posting role decisions as structured PR comments.
+- Moving labels based on explicit role decisions.
 
-Each wrapper currently uses an environment-specific placeholder executable (`forge-agent` by default, or `$FORGE_AGENT_CMD` if set). You must swap this for your real agent runner in your environment.
+What likely remains manual in the first step:
 
-Run Task 1 with one command:
+- Exact provisioning/auth details for Codex cloud org setup.
+- Final merge click after human confirmation.
+- Resolving ambiguous reviewer/product feedback loops.
+- Any capability not exposed by currently available Codex cloud/GitHub integration endpoints.
 
-```bash
-python3 scripts/run-task-chain.py 1 \
-  --builder-cmd 'bash scripts/run-builder.sh {task_id}' \
-  --reviewer-cmd 'bash scripts/run-reviewer.sh {task_id}' \
-  --product-cmd 'bash scripts/run-product.sh {task_id}'
-```
+---
 
+## What to keep, simplify, remove from current local orchestration
+
+### Keep
+
+- `orchestration/tasks.json` as canonical task list context.
+- `scripts/controller.py` state transition logic as reference behavior.
+- `REVIEW_RUBRIC.md`, `QUALITY_BAR.md`, and source-of-truth docs used by role prompts.
+
+### Simplify
+
+- Keep `scripts/run-task-chain.py` only as a **local fallback simulator**, not primary architecture.
+- Keep thin role wrappers only for local/dev debugging.
+
+### Remove (as primary path)
+
+- Dependence on local shell-chain as the main execution model.
+- Assumption that task progression is driven from workstation commands.
+
+---
+
+## Smallest first implementation step
+
+Implement one GitHub-driven Builder loop for a single task (then generalize to 1..19):
+
+1. Create/confirm issue `Task1` with `task:1` + `state:ready`.
+2. Add label `role:builder` (or comment `/build task:1`).
+3. GitHub Action receives event and invokes Codex cloud Builder with task context docs.
+4. Builder opens/updates PR and posts summary comment.
+5. Action sets `state:review` and applies `role:reviewer`.
+
+This is the smallest useful Codex-cloud-first foundation because it proves:
+- GitHub is in control,
+- Codex cloud can perform real implementation,
+- state transitions happen via GitHub artifacts.
+
+---
+
+## Proposed GitHub workflow / event model
+
+### Events
+
+- `issues.labeled` (preferred initial trigger)
+- `issue_comment.created` (optional slash-command trigger)
+- `pull_request` + `pull_request_review` + `check_suite.completed` for downstream transitions
+
+### Minimal workflow graph
+
+1. **Builder workflow**
+   - Trigger: issue labeled `role:builder` and `state:ready`.
+   - Action: run Codex Builder for task id from `task:<id>` label.
+   - Outputs: PR link comment on issue, labels -> `state:review` + `role:reviewer`.
+
+2. **Reviewer workflow**
+   - Trigger: PR labeled `role:reviewer` or issue labeled `state:review`.
+   - Action: run Codex Reviewer; post structured decision.
+   - Decision handling:
+     - `MERGE` -> `state:product-review`, label `role:product`.
+     - else -> `state:in-progress`, label `role:builder`.
+
+3. **Product-review workflow**
+   - Trigger: `role:product`.
+   - Action: run Codex Product-reviewer; post structured decision.
+   - Decision handling:
+     - `PROCEED` -> wait for CI + manual merge.
+     - else -> back to Builder.
+
+4. **CI workflow**
+   - Independent and honest; no orchestration job marks CI passed.
+
+---
+
+## Exactly how one task is triggered
+
+Example: trigger Task 7.
+
+1. Open issue for Task7 and ensure labels: `task:7`, `state:ready`.
+2. Add label `role:builder`.
+3. GitHub Action parses `task:7` and calls Codex cloud Builder with:
+   - `TASKLIST.md` Task7 section
+   - `VISION.md`, `PRODUCT.md`, `PHASE1.md`, `CONVENTIONS.md`, `ARCHITECTURE.md`, `QUALITY_BAR.md`, `REVIEW_RUBRIC.md`
+4. Builder creates/updates PR and posts a summary comment.
+5. Workflow swaps labels to `state:review` + `role:reviewer`.
+
+---
+
+## What remains manual after first step
+
+After implementing only the first Builder loop:
+
+- Reviewer and Product-reviewer are still manually triggered.
+- Decision comments may be manually interpreted for relabeling.
+- Final merge remains manual.
+- Retry/recovery policy for failed Codex runs remains manual.
+
+That manual remainder is acceptable for phase-1 orchestration because it is explicit, practical, and avoids pretending full autonomy before integrations are proven.


### PR DESCRIPTION
### Motivation

- Pivot the repo’s orchestration model away from a local shell-chain-first architecture toward a minimal, practical GitHub-first control plane and Codex-cloud-first execution plane.
- Make the Builder / Reviewer / Product-reviewer roles, label/state model, and event-driven flow explicit so task work (Tasks 1–19) can be driven by GitHub artifacts.
- Start with a small, honest foundation that automates what is practical today and clearly marks what remains manual.

### Description

- Rewrote `README.md` to define the target GitHub control plane, Codex cloud execution plane, role contracts, label/state conventions, event triggers, and a concrete smallest-first implementation step for a single Builder loop.
- Added an orchestration section to `ARCHITECTURE.md` capturing the control-plane/execution-plane split, role/state model, and the honest automation boundary for the first practical version.
- Kept the scope documentation-only and explicit about which local orchestration artifacts to keep (`orchestration/tasks.json`, `scripts/controller.py`), simplify (`scripts/run-task-chain.py`, thin wrappers), or stop treating as the primary path.
- Proposed the minimal workflow and triggers (issue labels and comment slash-commands) and a clear example of exactly how one task is triggered and advanced to review.

### Testing

- Ran `git status --short` to confirm working tree state and the command completed successfully.
- Ran `git diff -- README.md ARCHITECTURE.md` to inspect the documentation changes and the command completed successfully.
- Rendered `README.md` with `nl -ba README.md | sed -n '1,260p'` to verify file contents and the command completed successfully.
- Rendered `ARCHITECTURE.md` with `nl -ba ARCHITECTURE.md | sed -n '1,240p'` to verify file contents and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf5940f048322925e70ff4fa03f39)