### PR TITLE
Add Builder GitHub loop and task-builder issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-builder.md
+++ b/.github/ISSUE_TEMPLATE/task-builder.md
@@ -1,0 +1,32 @@
+---
+name: Task (Builder)
+about: Standard task issue for Codex-cloud Builder loop
+title: "Task <id>: <short description>"
+labels: ["state:ready", "role:builder"]
+---
+
+## Task
+- task label: `task:<id>`
+- scope: single task only
+
+## Acceptance criteria
+- [ ] Linked to relevant TASKLIST.md entry
+- [ ] Concrete implementation target described
+- [ ] Out-of-scope items explicitly listed
+
+## Context docs
+- `TASKLIST.md`
+- `VISION.md`
+- `PRODUCT.md`
+- `PHASE1.md`
+- `CONVENTIONS.md`
+- `ARCHITECTURE.md`
+- `QUALITY_BAR.md`
+- `REVIEW_RUBRIC.md`
+
+## Trigger
+Add label `role:builder` (or comment `/build`) to start the Builder loop.
+
+## Completion signal
+When the Codex Builder PR is open/updated, comment:
+`/builder-done pr:<pr-number-or-url>`

--- a/.github/workflows/builder-loop.yml
+++ b/.github/workflows/builder-loop.yml
@@ -1,0 +1,134 @@
+name: Builder Loop
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  request-builder:
+    if: |
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'role:builder') ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/build'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve task from issue labels
+        id: context
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue) {
+              core.setFailed('Builder loop only supports issue events.');
+              return;
+            }
+
+            const labels = issue.labels.map((l) => l.name);
+            const taskLabel = labels.find((name) => /^task:\d+$/.test(name));
+            const hasReady = labels.includes('state:ready');
+
+            if (!taskLabel) {
+              core.setFailed('Issue is missing a task:<id> label.');
+              return;
+            }
+
+            if (!hasReady) {
+              core.setFailed('Issue must have state:ready before builder can run.');
+              return;
+            }
+
+            const taskId = Number(taskLabel.split(':')[1]);
+            core.setOutput('task_id', String(taskId));
+            core.setOutput('issue_number', String(issue.number));
+            core.setOutput('labels', JSON.stringify(labels));
+
+      - name: Move issue to in-progress
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = Number('${{ steps.context.outputs.issue_number }}');
+            const currentLabels = JSON.parse('${{ steps.context.outputs.labels }}');
+            const nextLabels = currentLabels
+              .filter((l) => l !== 'state:ready')
+              .concat('state:in-progress');
+
+            const deduped = [...new Set(nextLabels)];
+            await github.rest.issues.setLabels({
+              ...context.repo,
+              issue_number,
+              labels: deduped,
+            });
+
+      - name: Comment with Codex-cloud Builder instructions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = Number('${{ steps.context.outputs.issue_number }}');
+            const task_id = '${{ steps.context.outputs.task_id }}';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueUrl = context.payload.issue.html_url;
+            const body = `Builder requested for task:${task_id}.\n\nUse this standard Codex Builder brief (copy/paste as-is):\n\n\`\`\`text\nImplement task:${task_id} for ${owner}/${repo}.\nSource of truth:\n- GitHub issue: ${issueUrl}\n- TASKLIST.md (task:${task_id})\n- VISION.md\n- PRODUCT.md\n- PHASE1.md\n- CONVENTIONS.md\n- ARCHITECTURE.md\n- QUALITY_BAR.md\n- REVIEW_RUBRIC.md\n\nConstraints:\n- Implement only this task.\n- Keep CI separate/honest.\n- Do not implement reviewer/product automation.\n\nExpected output:\n- Open or update a PR with code changes for task:${task_id}.\n- Post a concise implementation summary in the PR body.\n\`\`\`\n\nAfter PR is open/updated, comment here:\n\`/builder-done pr:<pr-number-or-url>\``;
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number,
+              body,
+            });
+
+  complete-builder:
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/builder-done')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Parse PR reference from completion command
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          PR_REF=$(printf '%s' "${COMMENT_BODY}" | sed -nE 's|.*pr:([^[:space:]]+).*|\1|p')
+          if [ -z "${PR_REF}" ]; then
+            echo "Expected /builder-done pr:<pr-number-or-url>"
+            exit 1
+          fi
+          echo "pr_ref=${PR_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Move labels to review state
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const issue_number = issue.number;
+            const labels = issue.labels.map((l) => l.name);
+
+            const next = labels
+              .filter((l) => !['role:builder', 'state:ready', 'state:in-progress'].includes(l))
+              .concat(['state:review', 'role:reviewer']);
+
+            await github.rest.issues.setLabels({
+              ...context.repo,
+              issue_number,
+              labels: [...new Set(next)],
+            });
+
+      - name: Post Builder completion summary
+        uses: actions/github-script@v7
+        env:
+          PR_REF: ${{ steps.parse.outputs.pr_ref }}
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const prRef = process.env.PR_REF;
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number,
+              body: `Builder marked complete with PR reference: ${prRef}.\n\nState moved to \`state:review\` + \`role:reviewer\`.`,
+            });

--- a/README.md
+++ b/README.md
@@ -145,6 +145,51 @@ Example: trigger Task 7.
 
 ---
 
+
+## Implemented now: minimal Builder-only GitHub loop
+
+A minimal Builder loop is implemented in `.github/workflows/builder-loop.yml`.
+
+### Exact event/trigger model
+
+- `issues.labeled` when label `role:builder` is added.
+- `issue_comment.created` with `/build` for manual trigger parity.
+- `issue_comment.created` with `/builder-done pr:<pr-number-or-url>` to complete Builder.
+
+### What this workflow does
+
+1. Validates task identification from GitHub issue labels:
+   - requires `task:<id>` label
+   - requires `state:ready`
+2. Moves issue label state to `state:in-progress`.
+3. Posts explicit instructions to run Builder in Codex cloud (no custom webhook service).
+4. On `/builder-done pr:<...>` comment:
+   - records PR reference in an issue comment
+   - transitions labels to `state:review` + `role:reviewer`
+5. Posts a reusable, standard Builder brief so operators do not need to invent a new prompt each task.
+
+### Honest boundary for Codex-cloud invocation
+
+This workflow intentionally avoids custom infrastructure. The remaining practical manual step is explicit:
+- run Builder in Codex cloud against this repository/task
+- open/update PR
+- comment `/builder-done pr:<pr-number-or-url>` on the issue
+
+CI remains separate in `.github/workflows/ci.yml`; the Builder loop does not mark CI passing.
+
+### Reusable task template format
+
+Use `.github/ISSUE_TEMPLATE/task-builder.md` for task issues. It preloads:
+- default labels `state:ready` + `role:builder`
+- required context docs
+- exact trigger and completion command format
+
+The workflow then posts a standard Codex Builder brief with:
+- repo + issue link
+- task label id
+- fixed source-of-truth docs
+- fixed constraints/output contract
+
 ## What remains manual after first step
 
 After implementing only the first Builder loop:


### PR DESCRIPTION
### Motivation
- Implement a minimal, explicit Builder orchestration loop that coordinates human-triggered Codex-cloud Builder runs for single tasks.
- Provide a reusable `task-builder` issue template so tasks are consistently labeled and include required context docs.
- Keep CI and infrastructure boundaries honest by avoiding custom webhooks and requiring the operator to run Codex-cloud Builder and open the PR.

### Description
- Add `.github/workflows/builder-loop.yml` which triggers on `issues.labeled` for `role:builder` and on issue comments (`/build` and `/builder-done`) and implements label validation, moves `state:ready`→`state:in-progress`, posts a standard Builder brief, and on `/builder-done pr:<...>` moves labels to `state:review` + `role:reviewer` and posts a completion comment.
- Add `.github/ISSUE_TEMPLATE/task-builder.md` which pre-populates labels, required context docs, trigger instructions, and the completion command format.
- Update `README.md` to document the new minimal Builder loop, its event model, what it does, and the honest boundary for Codex-cloud invocation.
- Use `actions/github-script@v7` for label and comment operations and shell parsing to extract the PR reference from the completion command.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf83544208322b9a2b391d15af1e7)