### PR TITLE
fix(builder-loop): avoid false in-progress without actual builder run

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-builder.md
+++ b/.github/ISSUE_TEMPLATE/task-builder.md
@@ -25,7 +25,8 @@ labels: ["state:ready", "role:builder"]
 - `REVIEW_RUBRIC.md`
 
 ## Trigger
-Add label `role:builder` (or comment `/build`) to start the Builder loop.
+- Add label `role:builder` to trigger automatic Builder execution (`codex-builder.yml`).
+- If automatic execution is unavailable, comment `/build` to trigger the manual fallback loop.
 
 ## Completion signal
 When the Codex Builder PR is open/updated, comment:

--- a/.github/workflows/builder-loop.yml
+++ b/.github/workflows/builder-loop.yml
@@ -1,8 +1,6 @@
 name: Builder Loop
 
 on:
-  issues:
-    types: [labeled]
   issue_comment:
     types: [created]
 
@@ -14,8 +12,7 @@ permissions:
 jobs:
   request-builder:
     if: |
-      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'role:builder') ||
-      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/build'))
+      github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/build')
     runs-on: ubuntu-latest
 
     steps:
@@ -75,7 +72,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issueUrl = context.payload.issue.html_url;
-            const body = `Builder requested for task:${task_id}.\n\nUse this standard Codex Builder brief (copy/paste as-is):\n\n\`\`\`text\nImplement task:${task_id} for ${owner}/${repo}.\nSource of truth:\n- GitHub issue: ${issueUrl}\n- TASKLIST.md (task:${task_id})\n- VISION.md\n- PRODUCT.md\n- PHASE1.md\n- CONVENTIONS.md\n- ARCHITECTURE.md\n- QUALITY_BAR.md\n- REVIEW_RUBRIC.md\n\nConstraints:\n- Implement only this task.\n- Keep CI separate/honest.\n- Do not implement reviewer/product automation.\n\nExpected output:\n- Open or update a PR with code changes for task:${task_id}.\n- Post a concise implementation summary in the PR body.\n\`\`\`\n\nAfter PR is open/updated, comment here:\n\`/builder-done pr:<pr-number-or-url>\``;
+            const body = `Manual Builder fallback requested for task:${task_id}.\n\nUse this standard Codex Builder brief (copy/paste as-is):\n\n\`\`\`text\nImplement task:${task_id} for ${owner}/${repo}.\nSource of truth:\n- GitHub issue: ${issueUrl}\n- TASKLIST.md (task:${task_id})\n- VISION.md\n- PRODUCT.md\n- PHASE1.md\n- CONVENTIONS.md\n- ARCHITECTURE.md\n- QUALITY_BAR.md\n- REVIEW_RUBRIC.md\n\nConstraints:\n- Implement only this task.\n- Keep CI separate/honest.\n- Do not implement reviewer/product automation.\n\nExpected output:\n- Open or update a PR with code changes for task:${task_id}.\n- Post a concise implementation summary in the PR body.\n\`\`\`\n\nAfter PR is open/updated, comment here:\n\`/builder-done pr:<pr-number-or-url>\`\n\nNote: label-driven automatic Builder execution is handled by \`codex-builder.yml\`.`;
 
             await github.rest.issues.createComment({
               ...context.repo,

--- a/README.md
+++ b/README.md
@@ -160,22 +160,23 @@ Example: trigger Task 7.
 ---
 
 
-## Implemented now: minimal Builder-only GitHub loop
+## Implemented now: Builder automation + manual fallback loop
 
-A minimal Builder loop is implemented in `.github/workflows/builder-loop.yml`.
+Automatic Builder execution is implemented in `.github/workflows/codex-builder.yml`.
+Manual fallback handling is implemented in `.github/workflows/builder-loop.yml`.
 
 ### Exact event/trigger model
 
-- `issues.labeled` when label `role:builder` is added.
-- `issue_comment.created` with `/build` for manual trigger parity.
-- `issue_comment.created` with `/builder-done pr:<pr-number-or-url>` to complete Builder.
+- Automatic path: `issues.labeled` when label `role:builder` is added (`codex-builder.yml`).
+- Manual fallback path: `issue_comment.created` with `/build` (`builder-loop.yml`).
+- Manual completion path: `issue_comment.created` with `/builder-done pr:<pr-number-or-url>` (`builder-loop.yml`).
 
 ### What this workflow does
 
-1. Validates task identification from GitHub issue labels:
+1. Manual fallback validates task identification from GitHub issue labels:
    - requires `task:<id>` label
    - requires `state:ready`
-2. Moves issue label state to `state:in-progress`.
+2. Moves issue label state to `state:in-progress` (manual fallback only).
 3. Posts explicit instructions to run Builder in Codex cloud (no custom webhook service).
 4. On `/builder-done pr:<...>` comment:
    - records PR reference in an issue comment
@@ -184,7 +185,7 @@ A minimal Builder loop is implemented in `.github/workflows/builder-loop.yml`.
 
 ### Honest boundary for Codex-cloud invocation
 
-This workflow intentionally avoids custom infrastructure. The remaining practical manual step is explicit:
+The fallback workflow intentionally avoids custom infrastructure. The remaining practical manual step is explicit:
 - run Builder in Codex cloud against this repository/task
 - open/update PR
 - comment `/builder-done pr:<pr-number-or-url>` on the issue


### PR DESCRIPTION
### Motivation
- The manual fallback workflow was reacting to `role:builder` label events and moving issues to `state:in-progress` even when the automatic Codex Builder path (`codex-builder.yml`) should have been used. 
- This caused operator confusion and issues appearing to be in-progress with no Builder work executed. 
- The change clarifies and enforces separation between the automatic label-driven Builder path and a comment-driven manual fallback.

### Description
- Restrict `.github/workflows/builder-loop.yml` to only trigger on issue comments starting with `/build` instead of also responding to `issues.labeled`, so label-driven runs are handled exclusively by `codex-builder.yml`.
- Update the fallback comment text in `builder-loop.yml` to explicitly label the comment as a manual fallback and to note that `codex-builder.yml` handles automatic label-driven execution.
- Update `README.md` to document two distinct paths: automatic Builder execution (`codex-builder.yml`) and the manual fallback (`builder-loop.yml`).
- Update `.github/ISSUE_TEMPLATE/task-builder.md` to instruct users to use the `role:builder` label for automatic execution and `/build` as a backup manual trigger.

### Testing
- Ran `git diff --check` to ensure no whitespace or patch issues, and it completed successfully.
- Verified working tree changes with `git status --short` to confirm the expected files were modified, and the check succeeded.
- Created a commit for the changes (`fix(builder-loop): keep label trigger for automatic builder only`), and the commit operation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1bc5b8648322b7d47359c4ffe2d8)